### PR TITLE
Make Abnormals Core handle poison potato compat

### DIFF
--- a/src/main/java/com/teamabnormals/abnormals_core/common/entity/IAgeableEntity.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/common/entity/IAgeableEntity.java
@@ -1,0 +1,15 @@
+package com.teamabnormals.abnormals_core.common.entity;
+
+/***
+ * @author Voliant
+ * Use to make an entity compatible with Quark's potato poisoning.
+ */
+public interface IAgeableEntity {
+
+    /**
+     * Sets the growing age of the entity. With a negative value it's considered a child; use this method to check for
+     * an age of 0 or greater and trigger the necessary changes.
+     */
+    void setGrowingAge(int age);
+
+}

--- a/src/main/java/com/teamabnormals/abnormals_core/common/entity/IAgeableEntity.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/common/entity/IAgeableEntity.java
@@ -12,4 +12,6 @@ public interface IAgeableEntity {
      */
     void setGrowingAge(int age);
 
+    int getGrowingAge();
+
 }

--- a/src/main/java/com/teamabnormals/abnormals_core/core/config/ACConfig.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/core/config/ACConfig.java
@@ -15,6 +15,9 @@ public class ACConfig {
 	public static class Common {
 		public final ConfigValue<Boolean> enableQuarkSignEditing;
 		public final ConfigValue<Boolean> signEditingRequiresEmptyHand;
+		public final ConfigValue<Boolean> poisonPotatoCompatEnabled;
+		public final ConfigValue<Boolean> poisonEffect;
+		public final ConfigValue<Double> poisonChance;
 		
 		Common(ForgeConfigSpec.Builder builder) {
 			builder.comment("Common only settings for Abnormals Core, this will affect all depending mods")
@@ -29,7 +32,25 @@ public class ACConfig {
 				.comment("If Quark Sign Editing requires an empty hand to edit; Default: False")
 				.translation(makeTranslation("require_empty_hand"))
 				.define("signEditingRequiresEmptyHand", false);
-			
+
+			builder.comment("Compatibility with Quark's poisonous potatoes feature")
+			.push("poisonousPotatoCompat");
+			poisonPotatoCompatEnabled = builder
+					.comment("If booflos can be fed a poisonous potato to stunt their growth when Quark is installed; Default: True")
+					.translation(makeTranslation("poison_potato_compat_enabled"))
+					.define("poisonPotatoCompatEnabled",true);
+
+			poisonEffect = builder
+					.comment("If growth stunting should give a booflo poison; Default: True")
+					.translation(makeTranslation("poison_effect"))
+					.define("poisonEffect",true);
+
+			poisonChance = builder
+					.comment("The chance to stunt booflo growth when feeding a poisonous potato; Default: 0.1")
+					.translation(makeTranslation("poison_chance"))
+					.defineInRange("poisonChance",0.1,0,1);
+
+			builder.pop();
 			builder.pop();
 		}
 	}
@@ -49,18 +70,36 @@ public class ACConfig {
 	public static class ValuesHolder {
 		private static boolean quarkSignEditing;
 		private static boolean signEditingRequireEmptyHand;
-		
+		private static boolean poisonPotatoCompatEnabled;
+		private static boolean poisonEffect;
+		private static double poisonChance;
+
 		public static void updateCommonValuesFromConfig(ModConfig config) {
 			quarkSignEditing = ACConfig.COMMON.enableQuarkSignEditing.get();
 			signEditingRequireEmptyHand = ACConfig.COMMON.signEditingRequiresEmptyHand.get();
+			poisonPotatoCompatEnabled = ACConfig.COMMON.poisonPotatoCompatEnabled.get();
+			poisonEffect = ACConfig.COMMON.poisonEffect.get();
+			poisonChance = ACConfig.COMMON.poisonChance.get();
 		}
-		
+
 		public static boolean isQuarkSignEditingEnabled() {
 			return ModList.get().isLoaded("quark") && quarkSignEditing;
 		}
-		
+
 		public static boolean doesSignEditingRequireEmptyHand() {
 			return signEditingRequireEmptyHand;
+		}
+
+		public static boolean isPoisonPotatoCompatEnabled() {
+			return poisonPotatoCompatEnabled;
+		}
+
+		public static boolean shouldPoisonEntity() {
+			return poisonEffect;
+		}
+
+		public static double poisonEffectChance() {
+			return poisonChance;
 		}
 	}
  

--- a/src/main/java/com/teamabnormals/abnormals_core/core/events/CompatEvents.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/core/events/CompatEvents.java
@@ -26,7 +26,7 @@ public class CompatEvents {
     @SubscribeEvent
     public static void onRightClickEntity(PlayerInteractEvent.EntityInteract event) {
         if(event.getTarget() instanceof IAgeableEntity && event.getItemStack().getItem() == Items.POISONOUS_POTATO && ACConfig.ValuesHolder.isPoisonPotatoCompatEnabled() && ModList.get().isLoaded("quark")) {
-            if(!event.getTarget().getPersistentData().getBoolean(poisonTag) && !event.getWorld().isRemote) {
+            if(((IAgeableEntity)event.getTarget()).getGrowingAge() < 0 && !event.getTarget().getPersistentData().getBoolean(poisonTag) && !event.getWorld().isRemote) {
                 //Vec3d pos = creepie.getPositionVec();
                 event.getPlayer().swingArm(event.getHand());
                 if(event.getTarget().world.rand.nextDouble() < ACConfig.ValuesHolder.poisonEffectChance()) {

--- a/src/main/java/com/teamabnormals/abnormals_core/core/events/CompatEvents.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/core/events/CompatEvents.java
@@ -1,0 +1,55 @@
+package com.teamabnormals.abnormals_core.core.events;
+
+import com.teamabnormals.abnormals_core.common.entity.IAgeableEntity;
+import com.teamabnormals.abnormals_core.core.AbnormalsCore;
+import com.teamabnormals.abnormals_core.core.config.ACConfig;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.Items;
+import net.minecraft.potion.EffectInstance;
+import net.minecraft.potion.Effects;
+import net.minecraft.util.SoundEvents;
+import net.minecraftforge.event.entity.living.LivingEvent;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.ModList;
+import net.minecraftforge.fml.common.Mod;
+
+/**
+ * @author Voliant
+ * Events for mod compatibility.
+ */
+@Mod.EventBusSubscriber(modid = AbnormalsCore.MODID)
+public class CompatEvents {
+
+    public static final String poisonTag = AbnormalsCore.MODID + ":poisoned_by_potato";
+
+    @SubscribeEvent
+    public static void onRightClickEntity(PlayerInteractEvent.EntityInteract event) {
+        if(event.getTarget() instanceof IAgeableEntity && event.getItemStack().getItem() == Items.POISONOUS_POTATO && ACConfig.ValuesHolder.isPoisonPotatoCompatEnabled() && ModList.get().isLoaded("quark")) {
+            if(!event.getTarget().getPersistentData().getBoolean(poisonTag) && !event.getWorld().isRemote) {
+                //Vec3d pos = creepie.getPositionVec();
+                event.getPlayer().swingArm(event.getHand());
+                if(event.getTarget().world.rand.nextDouble() < ACConfig.ValuesHolder.poisonEffectChance()) {
+                    event.getTarget().playSound(SoundEvents.ENTITY_GENERIC_EAT, 0.5f, 0.25f);
+                    //TODO reactivate this if fixed in Quark
+                    //if(((LivingEntity)event.getTarget()).isServerWorld()) ((ServerWorld)event.getTarget().world).spawnParticle(ParticleTypes.ENTITY_EFFECT, pos.x, pos.y, pos.z, 5, 0, 1.0, 0, 0.8);
+                    event.getTarget().getPersistentData().putBoolean(poisonTag, true);
+                    if(ACConfig.ValuesHolder.shouldPoisonEntity()) {
+                        ((LivingEntity) event.getTarget()).addPotionEffect(new EffectInstance(Effects.POISON, 200));
+                    } else {
+                        event.getTarget().playSound(SoundEvents.ENTITY_GENERIC_EAT, 0.5f, 0.5f + event.getTarget().world.rand.nextFloat() / 2);
+                        //if(((LivingEntity)event.getTarget()).isServerWorld()) ((ServerWorld)event.getTarget().world).spawnParticle(ParticleTypes.SMOKE, pos.x, pos.y, pos.z, 5, 0, 1.0, 0, 0.1);
+                    }
+                    if(!event.getPlayer().isCreative()) event.getItemStack().shrink(1);
+                }
+            }
+        }
+    }
+
+    @SubscribeEvent
+    public static void onUpdateEntity(LivingEvent.LivingUpdateEvent event) {
+        if(event.getEntity() instanceof IAgeableEntity && ACConfig.ValuesHolder.isPoisonPotatoCompatEnabled() && ModList.get().isLoaded("quark")) {
+            if (event.getEntity().getPersistentData().getBoolean(poisonTag)) ((IAgeableEntity)event.getEntity()).setGrowingAge(-24000);
+        }
+    }
+}


### PR DESCRIPTION
With this pull request, entities now only need to implement the new `IAgeableEntity` interface (which contains methods for getting and setting the growing age) and abnormals core will make them compatible with Quark's poison potato feature.