### PR TITLE
Added ability to redirect players to other servers

### DIFF
--- a/src/main/java/com/teamabnormals/abnormals_core/common/network/MessageS2CServerRedirect.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/common/network/MessageS2CServerRedirect.java
@@ -19,38 +19,38 @@ public final class MessageS2CServerRedirect {
     private static final Minecraft MINECRAFT = Minecraft.getInstance();
     private final String connectionAddress;
 
-	public MessageS2CServerRedirect(String address) {
-		this.connectionAddress = address;
-	}
+    public MessageS2CServerRedirect(String address) {
+        this.connectionAddress = address;
+    }
 
-	public void serialize(PacketBuffer buf) {
-		buf.writeString(this.connectionAddress);
-	}
+    public void serialize(PacketBuffer buf) {
+        buf.writeString(this.connectionAddress);
+    }
 
-	public static MessageS2CServerRedirect deserialize(PacketBuffer buf) {
-		return new MessageS2CServerRedirect(buf.readString());
-	}
+    public static MessageS2CServerRedirect deserialize(PacketBuffer buf) {
+        return new MessageS2CServerRedirect(buf.readString());
+    }
 
-	public static void handle(MessageS2CServerRedirect message, Supplier<NetworkEvent.Context> ctx) {
-		NetworkEvent.Context context = ctx.get();
-		if (context.getDirection().getReceptionSide() == LogicalSide.CLIENT) {
-			context.enqueueWork(() -> {
-				World world = MINECRAFT.world;
-				Screen currentScreen = MINECRAFT.currentScreen;
-				boolean integrated = MINECRAFT.isIntegratedServerRunning();
+    public static void handle(MessageS2CServerRedirect message, Supplier<NetworkEvent.Context> ctx) {
+        NetworkEvent.Context context = ctx.get();
+        if (context.getDirection().getReceptionSide() == LogicalSide.CLIENT) {
+            context.enqueueWork(() -> {
+                World world = MINECRAFT.world;
+                Screen currentScreen = MINECRAFT.currentScreen;
+                boolean integrated = MINECRAFT.isIntegratedServerRunning();
 
-				if (world != null) {
+                if (world != null) {
                     world.sendQuittingDisconnectingPacket();
                     MINECRAFT.unloadWorld(new DirtMessageScreen(new TranslationTextComponent("abnormals_core.message.redirect")));
 
                     MainMenuScreen menuScreen = new MainMenuScreen();
                     MINECRAFT.displayGuiScreen(integrated ? menuScreen : new MultiplayerScreen(menuScreen));
 
-					if (currentScreen != null)
+                    if (currentScreen != null)
                         MINECRAFT.displayGuiScreen(new ConnectingScreen(currentScreen, MINECRAFT, new ServerData("Redirect", message.connectionAddress, false)));
-				}
-			});
-			context.setPacketHandled(true);
-		}
-	}
+                }
+            });
+            context.setPacketHandled(true);
+        }
+    }
 }

--- a/src/main/java/com/teamabnormals/abnormals_core/common/network/MessageS2CServerRedirect.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/common/network/MessageS2CServerRedirect.java
@@ -16,41 +16,41 @@ import java.util.function.Supplier;
  * @author Jackson
  */
 public final class MessageS2CServerRedirect {
-    private static final Minecraft MINECRAFT = Minecraft.getInstance();
-    private final String connectionAddress;
+	private static final Minecraft MINECRAFT = Minecraft.getInstance();
+	private final String connectionAddress;
 
-    public MessageS2CServerRedirect(String address) {
-        this.connectionAddress = address;
-    }
+	public MessageS2CServerRedirect(String address) {
+		this.connectionAddress = address;
+	}
 
-    public void serialize(PacketBuffer buf) {
-        buf.writeString(this.connectionAddress);
-    }
+	public void serialize(PacketBuffer buf) {
+		buf.writeString(this.connectionAddress);
+	}
 
-    public static MessageS2CServerRedirect deserialize(PacketBuffer buf) {
-        return new MessageS2CServerRedirect(buf.readString());
-    }
+	public static MessageS2CServerRedirect deserialize(PacketBuffer buf) {
+		return new MessageS2CServerRedirect(buf.readString());
+	}
 
-    public static void handle(MessageS2CServerRedirect message, Supplier<NetworkEvent.Context> ctx) {
-        NetworkEvent.Context context = ctx.get();
-        if (context.getDirection().getReceptionSide() == LogicalSide.CLIENT) {
-            context.enqueueWork(() -> {
-                World world = MINECRAFT.world;
-                Screen currentScreen = MINECRAFT.currentScreen;
-                boolean integrated = MINECRAFT.isIntegratedServerRunning();
+	public static void handle(MessageS2CServerRedirect message, Supplier<NetworkEvent.Context> ctx) {
+		NetworkEvent.Context context = ctx.get();
+		if (context.getDirection().getReceptionSide() == LogicalSide.CLIENT) {
+			context.enqueueWork(() -> {
+				World world = MINECRAFT.world;
+				Screen currentScreen = MINECRAFT.currentScreen;
+				boolean integrated = MINECRAFT.isIntegratedServerRunning();
 
-                if (world != null) {
-                    world.sendQuittingDisconnectingPacket();
-                    MINECRAFT.unloadWorld(new DirtMessageScreen(new TranslationTextComponent("abnormals_core.message.redirect")));
+				if (world != null) {
+					world.sendQuittingDisconnectingPacket();
+					MINECRAFT.unloadWorld(new DirtMessageScreen(new TranslationTextComponent("abnormals_core.message.redirect")));
 
-                    MainMenuScreen menuScreen = new MainMenuScreen();
-                    MINECRAFT.displayGuiScreen(integrated ? menuScreen : new MultiplayerScreen(menuScreen));
+					MainMenuScreen menuScreen = new MainMenuScreen();
+					MINECRAFT.displayGuiScreen(integrated ? menuScreen : new MultiplayerScreen(menuScreen));
 
-                    if (currentScreen != null)
-                        MINECRAFT.displayGuiScreen(new ConnectingScreen(currentScreen, MINECRAFT, new ServerData("Redirect", message.connectionAddress, false)));
-                }
-            });
-            context.setPacketHandled(true);
-        }
-    }
+					if (currentScreen != null)
+						MINECRAFT.displayGuiScreen(new ConnectingScreen(currentScreen, MINECRAFT, new ServerData("Redirect", message.connectionAddress, false)));
+				}
+			});
+			context.setPacketHandled(true);
+		}
+	}
 }

--- a/src/main/java/com/teamabnormals/abnormals_core/common/network/MessageS2CServerRedirect.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/common/network/MessageS2CServerRedirect.java
@@ -7,7 +7,6 @@ import net.minecraft.client.gui.screen.MainMenuScreen;
 import net.minecraft.client.gui.screen.MultiplayerScreen;
 import net.minecraft.client.multiplayer.ServerData;
 import net.minecraft.network.PacketBuffer;
-import net.minecraft.util.text.StringTextComponent;
 import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.network.NetworkEvent;
@@ -16,7 +15,6 @@ import java.util.function.Supplier;
 
 /**
  * Allows servers to redirect clients to another server.
- *
  * @author Jackson
  */
 public class MessageS2CServerRedirect {

--- a/src/main/java/com/teamabnormals/abnormals_core/common/network/MessageS2CServerRedirect.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/common/network/MessageS2CServerRedirect.java
@@ -8,6 +8,7 @@ import net.minecraft.client.gui.screen.MultiplayerScreen;
 import net.minecraft.client.multiplayer.ServerData;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.network.NetworkEvent;
 
@@ -19,7 +20,6 @@ import java.util.function.Supplier;
  * @author Jackson
  */
 public class MessageS2CServerRedirect {
-
     private final String connectionAddress;
 
     public MessageS2CServerRedirect(String address) {
@@ -42,7 +42,7 @@ public class MessageS2CServerRedirect {
                 boolean integrated = minecraft.isIntegratedServerRunning();
                 if (minecraft.world != null) {
                     minecraft.world.sendQuittingDisconnectingPacket();
-                    minecraft.unloadWorld(new DirtMessageScreen(new StringTextComponent("Redirecting...")));
+                    minecraft.unloadWorld(new DirtMessageScreen(new TranslationTextComponent("abnormals_core.message.redirect")));
 
                     if (integrated) minecraft.displayGuiScreen(new MainMenuScreen());
                     else minecraft.displayGuiScreen(new MultiplayerScreen(new MainMenuScreen()));

--- a/src/main/java/com/teamabnormals/abnormals_core/common/network/MessageS2CServerRedirect.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/common/network/MessageS2CServerRedirect.java
@@ -1,0 +1,57 @@
+package com.teamabnormals.abnormals_core.common.network;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screen.ConnectingScreen;
+import net.minecraft.client.gui.screen.DirtMessageScreen;
+import net.minecraft.client.gui.screen.MainMenuScreen;
+import net.minecraft.client.gui.screen.MultiplayerScreen;
+import net.minecraft.client.multiplayer.ServerData;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraftforge.fml.LogicalSide;
+import net.minecraftforge.fml.network.NetworkEvent;
+
+import java.util.function.Supplier;
+
+/**
+ * Allows servers to redirect clients to another server.
+ *
+ * @author Jackson
+ */
+public class MessageS2CServerRedirect {
+
+    private final String connectionAddress;
+
+    public MessageS2CServerRedirect(String address) {
+        this.connectionAddress = address;
+    }
+
+    public void serialize(PacketBuffer buf) {
+        buf.writeString(this.connectionAddress);
+    }
+
+    public static MessageS2CServerRedirect deserialize(PacketBuffer buf) {
+        return new MessageS2CServerRedirect(buf.readString());
+    }
+
+    public static void handle(MessageS2CServerRedirect message, Supplier<NetworkEvent.Context> ctx) {
+        NetworkEvent.Context context = ctx.get();
+        if (context.getDirection().getReceptionSide() == LogicalSide.CLIENT) {
+            context.enqueueWork(() -> {
+                Minecraft minecraft = Minecraft.getInstance();
+                boolean integrated = minecraft.isIntegratedServerRunning();
+                if (minecraft.world != null) {
+                    minecraft.world.sendQuittingDisconnectingPacket();
+                    minecraft.unloadWorld(new DirtMessageScreen(new StringTextComponent("Redirecting...")));
+
+                    if (integrated) minecraft.displayGuiScreen(new MainMenuScreen());
+                    else minecraft.displayGuiScreen(new MultiplayerScreen(new MainMenuScreen()));
+
+                    if (minecraft.currentScreen != null)
+                        minecraft.displayGuiScreen(new ConnectingScreen(minecraft.currentScreen, minecraft, new ServerData("Redirect", message.connectionAddress, false)));
+                }
+            });
+            context.setPacketHandled(true);
+        }
+    }
+}

--- a/src/main/java/com/teamabnormals/abnormals_core/core/AbnormalsCore.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/core/AbnormalsCore.java
@@ -193,6 +193,11 @@ public class AbnormalsCore {
 		.encoder(MessageC2S2CSpawnParticle::serialize).decoder(MessageC2S2CSpawnParticle::deserialize)
 		.consumer(MessageC2S2CSpawnParticle::handle)
 		.add();
+
+		CHANNEL.messageBuilder(MessageS2CServerRedirect.class, id++)
+		.encoder(MessageS2CServerRedirect::serialize).decoder(MessageS2CServerRedirect::deserialize)
+		.consumer(MessageS2CServerRedirect::handle)
+		.add();
 	}
 	
 	/*

--- a/src/main/java/com/teamabnormals/abnormals_core/core/utils/NetworkUtil.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/core/utils/NetworkUtil.java
@@ -114,4 +114,20 @@ public final class NetworkUtil {
 	public static void openSignScreen(AbnormalsSignTileEntity sign) {
 		ClientInfo.MINECRAFT.displayGuiScreen(new AbnormalsEditSignScreen(sign));
 	}
+
+	/**
+	 * Send a packet to the client to redirect them to another server
+	 * @param address - The address to connect to
+	 */
+	public static void redirectToServer(ServerPlayerEntity player, String address) {
+		AbnormalsCore.CHANNEL.send(PacketDistributor.PLAYER.with(() -> player), new MessageS2CServerRedirect(address));
+	}
+
+	/**
+	 * Send a packet to all clients to redirect them to another server
+	 * @param address - The address to connect to
+	 */
+	public static void redirectAllToServer(String address) {
+		AbnormalsCore.CHANNEL.send(PacketDistributor.ALL.noArg(), new MessageS2CServerRedirect(address));
+	}
 }

--- a/src/main/resources/assets/abnormals_core/lang/en_us.json
+++ b/src/main/resources/assets/abnormals_core/lang/en_us.json
@@ -1,5 +1,6 @@
 {
 	"abnormals_core.config.quark_sign_editing": "Quark Sign Editing",
 	"abnormals_core.config.require_empty_hand": "Quark Sign Editing Requires Empty Hand",
+	"abnormals_core.message.redirect": "Redirecting",
 	"entity.abnormals_core.boat": "Boat"
 }


### PR DESCRIPTION
This pull request adds the ability for the server to redirect a player to another server.

To use this, call `NetworkUtils#redirectToServer(ServerPlayerEntity, String)` to redirect a specific player or `NetworkUtils#redirectAllToServer(String)` to redirect all currently connected players to the specified address.

Once the client receives the packet, it then disconnects, unloads the world, and opens a new `ConnectingScreen` with the specified address which connects the client to a new server.