### PR TITLE
[1.16.3] Add a class containing the mod id's of Abnormals and Aurora mods

### DIFF
--- a/src/main/java/com/teamabnormals/abnormals_core/core/other/CompatMods.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/core/other/CompatMods.java
@@ -1,0 +1,32 @@
+package com.teamabnormals.abnormals_core.core.other;
+
+public class CompatMods {
+	
+	public static class VazkiiMods {
+		public static final String QUARK 				= "quark";
+	}
+	
+	public static class AbnormalsMods {
+		public static final String ATMOSPHERIC 			= "atmospheric";
+		public static final String AUTUMNITY 			= "autumnity";
+		public static final String BAMBOO_BLOCKS 		= "bamboo_blocks";
+		public static final String BERRY_GOOD			= "berry_good";
+		public static final String BUZZIER_BEES			= "buzzier_bees";
+		public static final String ENDERGETIC_EXPANSION = "endergetic";
+		public static final String ENVIRONMENTAL 		= "environmental";
+		public static final String EXTRA_BOATS			= "extraboats";
+		public static final String NEAPOLITAN 			= "neapolitan";
+		// public static final String NETHER_EXTENSION = "nether_extension";
+		public static final String SAVAGE_AND_RAVAGE 	= "savageandravage";
+		public static final String UPGRADE_AQUATIC 		= "upgrade_aquatic";
+	}
+	
+	public static class AuroraMods {
+		public static final String BETTER_BADLANDS		= "better_badlands";
+		public static final String ENHANCED_MUSHROOMS	= "enhanced_mushrooms";
+		public static final String FROSTBURN_EXPANSION	= "frostburn_expansion";
+		public static final String FRUITFUL				= "fruitful";
+		public static final String HANAMI 				= "hanami";
+	}
+	
+}


### PR DESCRIPTION
This PR adds a class containing the mod id's of all Abnormals and Aurora mods, similar to the class found in Buzzier Bees. The advantage of having this class in Abnormals Core is twofold: it makes it impossible to misspell mod id's in code, cutting down a potential source of frustration, and makes it so that modders do not need to remember the intricacies of these strings (e.g. it's `savageandravage` with no underscores but `buzzier_bees` with an underscore, or the mod id for Endergetic Expansion is just `endergetic`).

Also Github completely botched the formatting when I committed this, apologies for that.